### PR TITLE
Add: Linked code of conduct in contributors guideline

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -68,7 +68,7 @@ npm run test
 By submitting a contribution, you affirm that you have the right to, and do, license your contribution under the project’s open source license.
 
 ## 🧠 Code of Conduct
-* We follow the Contributor Covenant Code of Conduct.
+* Please check our [Code of conduct](https://manush-e-docs.monerbondhu.com/code-of-conduct/) page before interacting with our repositories.
 * All interactions should be respectful and inclusive.
 
 ## 🙌 Need Help?

--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -2,8 +2,6 @@
 
 Thank you for considering contributing to the Manush-E frontend app! We welcome bug reports, feature suggestions, code improvements, and documentation help.
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
-
 ---
 
 ## 📌 How to Contribute
@@ -75,5 +73,3 @@ By submitting a contribution, you affirm that you have the right to, and do, lic
 Look for issues labeled good first issue or help wanted
 
 You can also reach out via email at [info@monerbondhu.com](mailto:info@monerbondhu.com)
-
-This guide incorporates the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, and is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0).


### PR DESCRIPTION
Added a link to our code of conduct documentation in our contributing guideline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Contribution Guide to reference the project’s Code of Conduct page.
  - Removed Contributor Covenant badge and related references.
  - Replaced Code of Conduct wording to direct users to the linked page.
  - Cleaned up legacy mentions of Contributor Covenant v2.1 and CC BY 4.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->